### PR TITLE
Add ANSI interpretation of markdown

### DIFF
--- a/Converter.js
+++ b/Converter.js
@@ -20,7 +20,6 @@ class Converter {
       } else if (this.inPreformattedText) {
         this.html += `${line}\n`;
       } else if (line.trim() === '') {
-        validateFunc(line);
         this.handleParagraphEnd();
       } else {
         validateFunc(line);

--- a/Converter.js
+++ b/Converter.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const { tags, regexps } = require('./config/constants');
+const { tagsHtml, tagsAnsi, regexps } = require('./config/constants');
 
 class Converter {
-  constructor () {
+  constructor (options) {
     this.html = '';
     this.inPreformattedText = false;
     this.inParagraph = false;
+    this.tags = options.format === 'html' ? tagsHtml : tagsAnsi;
   }
 
   convertMd (markdown, validateFunc) {
@@ -14,7 +15,7 @@ class Converter {
     const lines = markdown.split('\n');
 
     for (const line of lines) {
-      if (line.trim() === tags.preformatted.md) {
+      if (line.trim() === this.tags.preformatted.md) {
         this.handlePreformattedStart();
       } else if (this.inPreformattedText) {
         this.html += `${line}\n`;
@@ -27,27 +28,27 @@ class Converter {
       }
     }
 
-    if (this.inParagraph) this.html += '</p>\n';
+    if (this.inParagraph) this.html += this.tags.paragraph.close;
 
     return this.html;
   }
 
   handlePreformattedStart () {
     this.handleParagraphStart();
-    this.html += this.inPreformattedText ? `${tags.preformatted.close}\n` : `${tags.preformatted.open}\n`;
+    this.html += this.inPreformattedText ? this.tags.preformatted.close : this.tags.preformatted.open;
     this.inPreformattedText = !this.inPreformattedText;
   }
 
   handleParagraphStart () {
     if (!this.inParagraph) {
-      this.html += '<p>\n';
+      this.html += this.tags.paragraph.open;
       this.inParagraph = true;
     }
   }
 
   handleParagraphEnd () {
     if (this.inParagraph) {
-      this.html += '</p>\n';
+      this.html += this.tags.paragraph.close;
       this.inParagraph = false;
     }
   }
@@ -60,9 +61,9 @@ class Converter {
 
   replaceFormattingTags (line) {
     let currentLine = line;
-    currentLine = currentLine.replace(regexps.bold, `${tags.bold.open}$1${tags.bold.close}`);
-    currentLine = currentLine.replace(regexps.italic, `${tags.italic.open}$2${tags.italic.close}`);
-    currentLine = currentLine.replace(regexps.monospaced, `${tags.monospaced.open}$1${tags.monospaced.close}`);
+    currentLine = currentLine.replace(regexps.bold, `${this.tags.bold.open}$1${this.tags.bold.close}`);
+    currentLine = currentLine.replace(regexps.italic, `${this.tags.italic.open}$2${this.tags.italic.close}`);
+    currentLine = currentLine.replace(regexps.monospaced, `${this.tags.monospaced.open}$1${this.tags.monospaced.close}`);
 
     return currentLine;
   }

--- a/Validator.js
+++ b/Validator.js
@@ -2,13 +2,13 @@
 
 const fs = require('fs').promises;
 const path = require('path');
-const { regexps, tags, inputExtensions, outputExtensions } = require('./config/constants');
+const { regexps, tagsHtml, inputExtensions, outputExtensions } = require('./config/constants');
 
 class Validator {
   constructor () {
     this.isValidFilepath = true;
     this.inPreformattedText = false;
-    this.mdTags = Object.entries(tags).map(([, mdTag]) => mdTag.md);
+    this.mdTags = Object.entries(tagsHtml).map(([, mdTag]) => mdTag.md);
     this.isClosedRegexps = Object.entries(regexps).map(([, regexp]) => regexp);
   }
 

--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ class App {
     this.filePaths = args;
     this.options = options;
     this.html = '';
-    this.converter = new Converter();
+    this.converter = new Converter(this.options);
     this.validator = new Validator();
   }
 

--- a/config/commander.js
+++ b/config/commander.js
@@ -17,7 +17,6 @@ program
     ])
   ).action((_, opts) => {
     if (!opts.format) opts.format = opts.out ? 'html' : 'ansi';
-    console.log(opts.format);
   });
 
 program.parse();

--- a/config/commander.js
+++ b/config/commander.js
@@ -1,13 +1,24 @@
 'use strict';
 
 const pckg = require('../package.json');
-const { program } = require('commander');
+const { Command, Option } = require('commander');
+
+const program = new Command();
 
 program
   .name('md-to-html-converter')
   .version(pckg.version)
   .argument('<mdFilePath>', 'Provide the path to markdown file')
-  .option('-o, --out <HTMLfilepath>', 'Provide the path to output file');
+  .option('-o, --out <outputPath>', 'Provide the path to output file')
+  .addOption(
+    new Option('-f, --format <format>', 'Provide the output option').choices([
+      'ansi',
+      'html'
+    ])
+  ).action((_, opts) => {
+    if (!opts.format) opts.format = opts.out ? 'html' : 'ansi';
+    console.log(opts.format);
+  });
 
 program.parse();
 

--- a/config/constants.js
+++ b/config/constants.js
@@ -1,10 +1,19 @@
 'use strict';
 
-const tags = {
+const tagsHtml = {
   bold: { md: '**', open: '<b>', close: '</b>' },
   italic: { md: '_', open: '<i>', close: '</i>' },
   monospaced: { md: '`', open: '<tt>', close: '</tt>' },
-  preformatted: { md: '```', open: '<pre>', close: '</pre>' }
+  preformatted: { md: '```', open: '<pre>\n', close: '</pre>\n' },
+  paragraph: { md: '\n', open: '<p>\n', close: '</p>\n' }
+};
+
+const tagsAnsi = {
+  bold: { md: '**', open: '\x1b[1m', close: '\x1b[0m' },
+  italic: { md: '_', open: '\x1b[3m', close: '\x1b[0m' },
+  monospaced: { md: '`', open: '\x1b[0;2m', close: '\x1b[0m' },
+  preformatted: { md: '```', open: '\x1b[0;2m', close: '\x1b[0m' },
+  paragraph: { md: '\n', open: '\n', close: '' }
 };
 
 const regexps = {
@@ -17,4 +26,4 @@ const inputExtensions = ['.md'];
 
 const outputExtensions = ['.html', '.txt'];
 
-module.exports = { tags, regexps, inputExtensions, outputExtensions };
+module.exports = { tagsHtml, tagsAnsi, regexps, inputExtensions, outputExtensions };


### PR DESCRIPTION
With the help of flag "--format" it is possible to choose between html and ANSI interpretation of markdown input.